### PR TITLE
Created more flexible logic for R&T level colors

### DIFF
--- a/src/components/RescueDetails.tsx
+++ b/src/components/RescueDetails.tsx
@@ -71,15 +71,16 @@ export default function RescueDetails({id}: { id: string }) {
     }
 
     const getRTLevelColor = (level: RTLevel) => {
-        switch (level) {
-            case 'Green: songbirds & babies':
-                return 'bg-green-600 hover:bg-green-800'
-            case 'Yellow: geese, ducks and swans':
-                return 'bg-yellow-600 hover:bg-yellow-800'
-            case 'Red: herons, bats':
-                return 'bg-red-600 hover:bg-red-800'
-            case 'Purple: raptors':
-                return 'bg-purple-600 hover:bg-purple-800'
+        if (level.toLowerCase().includes("green")) {
+            return 'bg-green-600 hover:bg-green-800'
+        }else if (level.toLowerCase().includes("yellow")) {
+            return 'bg-yellow-600 hover:bg-yellow-800'
+        }else if (level.toLowerCase().includes("red")) {
+            return 'bg-red-600 hover:bg-red-800'
+        }else if (level.toLowerCase().includes("purple")) {
+            return 'bg-purple-600 hover:bg-purple-800'
+        }else {
+            return 'bg-gray-500 hover:bg-gray-800'
         }
     }
 


### PR DESCRIPTION
I replaced the switch statement with an if statement that checks if the R&T level string contains the specified color. I also added an else statement to the end to catch any ones that don't match one of the current colors. In that case, it will just add a gray background.